### PR TITLE
[FEAT] S3 안무 영상 presigned URL 기능 추가

### DIFF
--- a/HEJZ_back/build.gradle
+++ b/HEJZ_back/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'software.amazon.awssdk:s3:2.25.10'
+	implementation 'software.amazon.awssdk:auth:2.25.10'
+
+
 
 	// 통일된 최신버전으로 변경 (Spring Boot 3.4.x 호환)
 	implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.1'

--- a/HEJZ_back/docker-compose.yml
+++ b/HEJZ_back/docker-compose.yml
@@ -33,9 +33,14 @@ services:
     depends_on:
       - mysql
     environment:
+      SPRING_PROFILES_ACTIVE: dev
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql_capstoneHEJZ:3306/${MYSQL_DATABASE}
       SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
       SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
+      SUNO_API_TOKEN: ${SUNO_API_TOKEN}
+      AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+      AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+
       #APP_JWT_SECRET: ${APP_JWT_SECRET}
       #APP_JWT_EXPIRATION_MS: ${APP_JWT_EXPIRATION_MS}
     networks:

--- a/HEJZ_back/src/main/java/com/HEJZ/HEJZ_back/domain/dance/controller/MotionController.java
+++ b/HEJZ_back/src/main/java/com/HEJZ/HEJZ_back/domain/dance/controller/MotionController.java
@@ -1,0 +1,21 @@
+package com.HEJZ.HEJZ_back.domain.dance.controller;
+
+import com.HEJZ.HEJZ_back.domain.dance.service.S3DanceVideoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/motion")
+public class MotionController {
+
+    private final S3DanceVideoService s3DanceVideoService;
+
+    @GetMapping("/{motionId}")
+    public ResponseEntity<Map<String, Object>> getMotionUrl(@PathVariable String motionId) {
+        return ResponseEntity.ok(s3DanceVideoService.getPresignedUrlForMotion(motionId));
+    }
+}

--- a/HEJZ_back/src/main/java/com/HEJZ/HEJZ_back/domain/dance/service/S3DanceVideoService.java
+++ b/HEJZ_back/src/main/java/com/HEJZ/HEJZ_back/domain/dance/service/S3DanceVideoService.java
@@ -1,0 +1,56 @@
+package com.HEJZ.HEJZ_back.domain.dance.service;
+
+import com.HEJZ.HEJZ_back.global.exception.CustomException;
+import com.HEJZ.HEJZ_back.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class S3DanceVideoService {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public Map<String, Object> getPresignedUrlForMotion(String motionId) {
+        try {
+            String key = "videos/" + motionId + ".mp4";
+
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .getObjectRequest(getObjectRequest)
+                    .signatureDuration(Duration.ofMinutes(10))
+                    .build();
+
+            URL presignedUrl = s3Presigner.presignGetObject(presignRequest).url();
+
+            Map<String, Object> result = new HashMap<>();
+            result.put("motionId", motionId);
+            result.put("type", "video");
+            result.put("fileUrl", presignedUrl.toString());
+
+            return result;
+
+        } catch (S3Exception e) {
+            throw new CustomException(ErrorCode.VIDEO_NOT_FOUND);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.UNKNOWN_SERVER_ERROR);
+        }
+    }
+}

--- a/HEJZ_back/src/main/java/com/HEJZ/HEJZ_back/domain/music/service/SunoService.java
+++ b/HEJZ_back/src/main/java/com/HEJZ/HEJZ_back/domain/music/service/SunoService.java
@@ -21,7 +21,7 @@ import java.util.List;
 @Service
 public class SunoService {
 
-    @Value("${suno.token}")
+    @Value("${suno.api.token}")
     private String token;
     public String requestToSuno(SunoRequest request){
         // Suno API로 HTTP 요청 보내는 코드

--- a/HEJZ_back/src/main/java/com/HEJZ/HEJZ_back/global/config/S3Config.java
+++ b/HEJZ_back/src/main/java/com/HEJZ/HEJZ_back/global/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.HEJZ.HEJZ_back.global.config;
+
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/HEJZ_back/src/main/java/com/HEJZ/HEJZ_back/global/exception/ErrorCode.java
+++ b/HEJZ_back/src/main/java/com/HEJZ/HEJZ_back/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     EMPTY_LYRICS(HttpStatus.BAD_REQUEST, "G004", "가사가 비어 있습니다."),
     INVALID_LYRICS_FORMAT(HttpStatus.BAD_REQUEST, "G005", "2줄 이상의 가사를 입력해주세요."),
     RECOMMENDATION_FAILED(HttpStatus.NOT_FOUND, "G006", "추천 결과가 존재하지 않습니다."),
+    VIDEO_NOT_FOUND(HttpStatus.NOT_FOUND, "G007", "해당 안무 영상이 존재하지 않습니다."),
 
     // === 시스템 에러 ===
     CSV_LOADING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "CSV 파일 로딩 실패"),

--- a/HEJZ_back/src/main/resources/application-dev.yml
+++ b/HEJZ_back/src/main/resources/application-dev.yml
@@ -29,6 +29,10 @@ spring:
       key: ${OPENAI_API_KEY}
       model: ${OPENAI_API_MODEL}
 
+  suno:
+    api:
+      token: ${SUNO_API_TOKEN}
+
 
 springdoc:
   api-docs:
@@ -39,7 +43,18 @@ springdoc:
     tagsSorter: alpha
     display-request-duration: true
 
-
+cloud:
+  aws:
+    s3:
+      bucket: ${CLOUD_AWS_S3_BUCKET}
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ${CLOUD_AWS_REGION_STATIC}
+      auto: false
+    stack:
+      auto: false
 #app:
 #  jwt:
 #    secret: ${APP_JWT_SECRET}


### PR DESCRIPTION
### 개요
S3에 저장된 안무 영상(mp4)에 접근할 수 있도록 presigned URL을 생성해 반환하는 기능을 추가했습니다.

### 주요 변경 사항
- `MotionController.java`
  - `/api/motions/{motionId}` GET API 구현
  - 요청 시 S3에 해당 영상이 존재하면 presigned URL 반환
- `S3DanceVideoService.java`
  - presigned URL 생성 로직 구현
  - 영상 존재하지 않을 경우 `VIDEO_NOT_FOUND` 예외 처리
- `S3Config.java`
  - `S3Presigner` Bean 등록
- `ErrorCode.java`
  - `VIDEO_NOT_FOUND` 에러 코드(`G007`) 추가
- `application-dev.yml`, `docker-compose.yml`
  - AWS KEY, SUNO 토큰 등 환경 변수 정리
- `build.gradle`
  - AWS S3 Presigner 관련 SDK 의존성 추가
- `SunoService.java`
  - Suno API 호출을 위한 token 주입 처리

### 주의 사항
- `.env`에 `AWS_ACCESS_KEY`, `AWS_SECRET_KEY` 필수
- S3에 `videos/{motionId}.mp4` 형식으로 파일이 있어야 정상 동작
- 존재하지 않는 영상에 대한 요청 시 `404 - VIDEO_NOT_FOUND` 반환

---

## 체크리스트
- [x] presigned URL이 정상적으로 생성되는지 확인
- [x] 존재하지 않는 영상 요청 시 예외가 발생하는지 확인
- [x] Swagger 또는 Postman으로 API 테스트 완료
- [x] `.env`에 필요한 값 추가 (`SUNO_API_TOKEN`, `AWS_ACCESS_KEY`, ...)

---

## 🧪 테스트 방법
GET /api/motions/gHO_sBM_cAll_d19_mHO0_ch01
-> 정상적으로 presigned URL이 반환되면 영상이 존재하는 것이며, 존재하지 않으면 예외가 발생해야 함.
