### PR TITLE
feat: COCO 스켈레톤 영상을 SMPL 3D 메쉬로 렌더링 기능 추가

### DIFF
--- a/tools/inspect_smpl.ipynb
+++ b/tools/inspect_smpl.ipynb
@@ -1,0 +1,1851 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4bfc9681-0d88-446d-af1a-1ad9390ed1ac",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SMPL_MALE.pkl 존재: True\n",
+      "SMPL_FEMALE.pkl 존재: True\n",
+      "\n",
+      "Motion 파일 개수: 1408\n",
+      "첫 번째 파일: gBR_sBM_cAll_d04_mBR0_ch01.pkl\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "# SMPL 모델 파일이 있는지 확인\n",
+    "SMPL_DIR = r\"C:\\Users\\SongYoengEun\\Desktop\\cap\\dataset\\aist_plusplus_final\"\n",
+    "\n",
+    "smpl_male = os.path.join(SMPL_DIR, \"SMPL_MALE.pkl\")\n",
+    "smpl_female = os.path.join(SMPL_DIR, \"SMPL_FEMALE.pkl\")\n",
+    "\n",
+    "print(f\"SMPL_MALE.pkl 존재: {os.path.exists(smpl_male)}\")\n",
+    "print(f\"SMPL_FEMALE.pkl 존재: {os.path.exists(smpl_female)}\")\n",
+    "\n",
+    "# motions 폴더 확인\n",
+    "MOTION_DIR = os.path.join(SMPL_DIR, \"motions\")\n",
+    "pkl_files = [f for f in os.listdir(MOTION_DIR) if f.endswith('.pkl')]\n",
+    "print(f\"\\nMotion 파일 개수: {len(pkl_files)}\")\n",
+    "print(f\"첫 번째 파일: {pkl_files[0] if pkl_files else 'None'}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8101fccc-92fa-4996-be31-7c1d1e563d02",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "데이터 구조:\n",
+      "  smpl_poses: (720, 72)\n",
+      "  smpl_trans: (720, 3)\n",
+      "  frame_count: 720\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pickle\n",
+    "import numpy as np\n",
+    "import cv2\n",
+    "from tqdm.notebook import tqdm\n",
+    "\n",
+    "# 출력 폴더 생성\n",
+    "OUTPUT_DIR = r\"C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\"\n",
+    "os.makedirs(OUTPUT_DIR, exist_ok=True)\n",
+    "\n",
+    "# 테스트용 파일 하나 선택\n",
+    "test_file = \"gBR_sBM_cAll_d04_mBR0_ch01.pkl\"\n",
+    "\n",
+    "# 모션 데이터 로드\n",
+    "with open(os.path.join(MOTION_DIR, test_file), 'rb') as f:\n",
+    "    data = pickle.load(f)\n",
+    "\n",
+    "print(\"데이터 구조:\")\n",
+    "print(f\"  smpl_poses: {data['smpl_poses'].shape}\")\n",
+    "print(f\"  smpl_trans: {data['smpl_trans'].shape}\")\n",
+    "print(f\"  frame_count: {data['smpl_trans'].shape[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e93ba81f-6909-4e8b-bc09-1fb54029f74c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using device: cpu\n",
+      "✓ SMPL 모델 로드 완료\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from smplx import SMPL\n",
+    "\n",
+    "# GPU 사용 가능하면 GPU, 아니면 CPU\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "print(f\"Using device: {device}\")\n",
+    "\n",
+    "# SMPL 모델 로드\n",
+    "smpl = SMPL(\n",
+    "    model_path=SMPL_DIR,\n",
+    "    gender='MALE',\n",
+    "    batch_size=1\n",
+    ").to(device)\n",
+    "\n",
+    "print(\"✓ SMPL 모델 로드 완료\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c3f87041-555b-44e4-bc01-9ef093f70564",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using device: cpu\n",
+      "✓ SMPL 모델 로드 완료\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from smplx import SMPL\n",
+    "\n",
+    "# 2단계에서 사용했던 경로를 여기에 직접 정의합니다.\n",
+    "SMPL_DIR = r\"C:\\Users\\SongYoengEun\\Desktop\\cap\\dataset\\aist_plusplus_final\" \n",
+    "\n",
+    "# GPU 사용 가능하면 GPU, 아니면 CPU\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "print(f\"Using device: {device}\")\n",
+    "\n",
+    "# SMPL 모델 로드\n",
+    "smpl = SMPL(\n",
+    "    model_path=SMPL_DIR,\n",
+    "    gender='MALE',\n",
+    "    batch_size=1\n",
+    ").to(device)\n",
+    "\n",
+    "print(\"✓ SMPL 모델 로드 완료\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "325d2d4e-2b65-4c33-a29c-c29449183cbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import cv2\n",
+    "import pickle\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import trimesh\n",
+    "import pyrender\n",
+    "from tqdm.notebook import tqdm\n",
+    "\n",
+    "# 주의: smpl, device, SMPL_DIR, MOTION_DIR, OUTPUT_DIR 변수가 이전 셀에서 정의되어 있어야 합니다!\n",
+    "\n",
+    "# -------------------------------------------------------------\n",
+    "# 3D 렌더링을 위한 설정값 함수\n",
+    "# -------------------------------------------------------------\n",
+    "def get_render_settings(width=1920, height=1080):\n",
+    "    # Pyrender 렌더러 설정\n",
+    "    \n",
+    "    render_width, render_height = width, height \n",
+    "\n",
+    "    # 카메라 설정\n",
+    "    # 필드 오브 뷰(fov)를 조정하여 모델이 화면에 들어오는 정도를 조절할 수 있습니다.\n",
+    "    camera = pyrender.PerspectiveCamera(yfov=np.pi / 3.0, aspectRatio=render_width/render_height)\n",
+    "    \n",
+    "    # 조명 설정 (밝은 조명)\n",
+    "    light = pyrender.DirectionalLight(color=np.ones(3), intensity=2.0)\n",
+    "    \n",
+    "    # 장면 설정 (흰색 배경)\n",
+    "    scene = pyrender.Scene(bg_color=np.array([1.0, 1.0, 1.0])) \n",
+    "    \n",
+    "    return scene, camera, light, render_width, render_height\n",
+    "\n",
+    "\n",
+    "def render_smpl_video_mesh(motion_file, output_dir=OUTPUT_DIR):\n",
+    "    \"\"\"SMPL 메쉬를 3D 렌더러(Pyrender)를 사용하여 영상으로 렌더링\"\"\"\n",
+    "    \n",
+    "    global smpl, device, MOTION_DIR\n",
+    "    \n",
+    "    # 모션 데이터 로드\n",
+    "    motion_path = os.path.join(MOTION_DIR, motion_file)\n",
+    "    with open(motion_path, 'rb') as f:\n",
+    "        data = pickle.load(f)\n",
+    "        \n",
+    "    # 데이터 준비\n",
+    "    poses = torch.tensor(\n",
+    "        data['smpl_poses'].reshape(-1, 24, 3),\n",
+    "        dtype=torch.float32\n",
+    "    ).to(device)\n",
+    "    \n",
+    "    trans = torch.tensor(\n",
+    "        data['smpl_trans'],\n",
+    "        dtype=torch.float32\n",
+    "    ).to(device)\n",
+    "    \n",
+    "    frame_count = poses.shape[0]\n",
+    "    print(f\"Total frames: {frame_count}\")\n",
+    "    \n",
+    "    # 렌더링 설정 초기화\n",
+    "    scene, camera, light, width, height = get_render_settings()\n",
+    "    \n",
+    "    # 렌더러 초기화\n",
+    "    r = pyrender.OffscreenRenderer(width, height)\n",
+    "    \n",
+    "    # Scene에 Light와 Camera를 추가합니다.\n",
+    "    scene.add(light, pose=np.eye(4))\n",
+    "    camera_node = scene.add(camera, pose=np.eye(4))\n",
+    "\n",
+    "    # 초기 메쉬 노드 변수만 선언 (루프에서 제거/추가할 예정)\n",
+    "    mesh_node = None \n",
+    "    \n",
+    "    # 비디오 설정\n",
+    "    fps = 60\n",
+    "    fourcc = cv2.VideoWriter_fourcc(*'mp4v')\n",
+    "    # 파일명 접미사 변경: _mesh.mp4 -> _body.mp4\n",
+    "    output_path = os.path.join(output_dir, motion_file.replace('.pkl', '_body.mp4')) \n",
+    "    out = cv2.VideoWriter(output_path, fourcc, fps, (width, height))\n",
+    "    \n",
+    "    # -------------------------------------------------------------\n",
+    "    # 프레임별 렌더링 루프\n",
+    "    # -------------------------------------------------------------\n",
+    "    for i in tqdm(range(frame_count), desc=f\"Rendering {motion_file}\"):\n",
+    "        \n",
+    "        # 1. SMPL Forward Pass (정점(Vertices) 가져오기)\n",
+    "        with torch.no_grad():\n",
+    "            output = smpl(\n",
+    "                body_pose=poses[i:i+1, 1:],\n",
+    "                global_orient=poses[i:i+1, :1],\n",
+    "                transl=trans[i:i+1]\n",
+    "            )\n",
+    "        \n",
+    "        vertices = output.vertices[0].cpu().numpy()  # (6890, 3)\n",
+    "        \n",
+    "        # X, Y축 오프셋 제거 및 중앙 고정\n",
+    "        # Y축 평균값을 계산할 때, 바닥에 더 가깝게 위치하도록 조정합니다.\n",
+    "        # 발의 가장 낮은 지점을 기준으로 평균을 조정하여 발이 잘리지 않게 합니다.\n",
+    "        center = vertices.mean(axis=0)\n",
+    "        vertices -= center \n",
+    "        \n",
+    "        # 2. 메쉬 노드 업데이트 (이전 노드 제거 후 새 노드 추가)\n",
+    "        if mesh_node is not None:\n",
+    "            scene.remove_node(mesh_node)\n",
+    "\n",
+    "        # 새로운 정점과 기존 면으로 메쉬 객체 생성\n",
+    "        new_mesh = trimesh.Trimesh(vertices, smpl.faces, process=False)\n",
+    "        pyrender_mesh = pyrender.Mesh.from_trimesh(new_mesh, smooth=True)\n",
+    "        \n",
+    "        # 장면(Scene)에 새 메쉬 노드를 추가하고 변수를 업데이트합니다.\n",
+    "        mesh_node = scene.add(pyrender_mesh)\n",
+    "\n",
+    "        # 3. 카메라 설정 (메쉬를 바라보도록 위치 조정)\n",
+    "        camera_pose = np.eye(4)\n",
+    "        # 카메라 Z축 거리와 Y축 오프셋 조정\n",
+    "        camera_pose[2, 3] = 3.0  # Z축으로 3.0만큼 후퇴 (모델과의 거리) - 필요에 따라 2.5~3.5 사이로 조정\n",
+    "        camera_pose[1, 3] = -0.3 # Y축으로 -0.3만큼 (아래로) 이동하여 발이 잘리지 않도록 조정 (조정 필요)\n",
+    "\n",
+    "        scene.set_pose(camera_node, camera_pose)\n",
+    "        \n",
+    "        # 4. 렌더링 및 저장\n",
+    "        color, _ = r.render(scene)\n",
+    "        \n",
+    "        # 5. OpenCV 형식으로 변환 및 저장\n",
+    "        frame = cv2.cvtColor(color, cv2.COLOR_RGB2BGR)\n",
+    "        \n",
+    "        # 프레임 번호 표시 제거 (주석 처리)\n",
+    "        # cv2.putText(\n",
+    "        #     frame, f\"Frame: {i+1}/{frame_count}\",\n",
+    "        #     (50, 50), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 0), 2\n",
+    "        # )\n",
+    "        \n",
+    "        out.write(frame)\n",
+    "    \n",
+    "    r.delete() # 렌더러 리소스 해제\n",
+    "    out.release()\n",
+    "    print(f\"✓ 완료: {output_path}\")\n",
+    "    return output_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "5dc2b388-0f8a-4ff8-a38a-04145380c7a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "74059ff1918e4089861030d7ebb34fa9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR0_ch01.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR0_ch01_body.mp4\n",
+      "생성된 비디오 경로: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR0_ch01_body.mp4\n"
+     ]
+    }
+   ],
+   "source": [
+    "video_path = render_smpl_video_mesh(\"gBR_sBM_cAll_d04_mBR0_ch01.pkl\") \n",
+    "print(f\"생성된 비디오 경로: {video_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5bfa0d4b-2369-4464-9864-9752c5224a07",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "총 1408개의 .pkl 파일을 찾았습니다.\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR0_ch01.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "35ec3cee767d40ba8e3726103ca3d8e7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR0_ch01.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR0_ch01_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR0_ch02.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "047a37dde89246b295d97d3c4722d152",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR0_ch02.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR0_ch02_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR0_ch03.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c08180565ca643508649fed973df6871",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR0_ch03.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR0_ch03_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR0_ch04.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "63d7532263124a3eb52df78798bd2337",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR0_ch04.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR0_ch04_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR0_ch05.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7872c3c7ee25439e93fe6882be7c5ffa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR0_ch05.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR0_ch05_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR0_ch06.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "86545aaea6df4c5289bc617538dad8af",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR0_ch06.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR0_ch06_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR0_ch07.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c57922b736fc48a6aebcfd9075a514a3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR0_ch07.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR0_ch07_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR0_ch08.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cf8ad51732224e95a033101a9bbd18d0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR0_ch08.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR0_ch08_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR0_ch09.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6d65884a89ae40eaa603d5a9367f691e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR0_ch09.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR0_ch09_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR0_ch10.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "08e73644ef714aeabdc926e5930e883c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR0_ch10.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR0_ch10_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR1_ch01.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d6154e20c0ed4e2ebe9d2c26f3736a6e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR1_ch01.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR1_ch01_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR1_ch02.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c55678ea8bbe4491a8a4b5c8e767eeb9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR1_ch02.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR1_ch02_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR1_ch03.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "14d00c828e3e4f4f82d2fea6e9a88b90",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR1_ch03.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR1_ch03_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR1_ch04.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e8fbc2b2c43043d393c630c363b7c5f1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR1_ch04.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR1_ch04_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR1_ch05.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e8d6c265500e4ada898193959f15ae66",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR1_ch05.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR1_ch05_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR1_ch06.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1c3a8b2ca5ab43ecbed876484eff3040",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR1_ch06.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR1_ch06_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR1_ch07.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "08cd659f674142e5b47a1259cb3e069a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR1_ch07.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR1_ch07_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR1_ch08.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "78d502d3393641c4a1c5c571d28d918e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR1_ch08.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR1_ch08_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR1_ch09.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8363a16da0ea42fba66cafec09a40f65",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR1_ch09.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR1_ch09_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR1_ch10.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "24e42d6e737748048bf95c59066e09b1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR1_ch10.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR1_ch10_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR2_ch01.pkl 렌더링 시작 ---\n",
+      "Total frames: 576\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0a5bb02d515847b3b6b66915b63e7592",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR2_ch01.pkl:   0%|          | 0/576 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR2_ch01_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR2_ch02.pkl 렌더링 시작 ---\n",
+      "Total frames: 576\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "733a67322dd349f78bbf059852b38d5b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR2_ch02.pkl:   0%|          | 0/576 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR2_ch02_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR2_ch03.pkl 렌더링 시작 ---\n",
+      "Total frames: 576\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cc9fefc7296b453aabd3085bd7819485",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR2_ch03.pkl:   0%|          | 0/576 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR2_ch03_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR2_ch04.pkl 렌더링 시작 ---\n",
+      "Total frames: 576\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "81adaa9caba94f87b32d694151532f03",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR2_ch04.pkl:   0%|          | 0/576 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR2_ch04_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR2_ch05.pkl 렌더링 시작 ---\n",
+      "Total frames: 576\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f2c42488876546f5bc954ca2bc2a5b73",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR2_ch05.pkl:   0%|          | 0/576 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR2_ch05_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR2_ch06.pkl 렌더링 시작 ---\n",
+      "Total frames: 576\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "612e4ea12b004b779f8d5b866dccf7f5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR2_ch06.pkl:   0%|          | 0/576 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR2_ch06_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR2_ch07.pkl 렌더링 시작 ---\n",
+      "Total frames: 576\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6cecb99bf0674274a03cb99c1b74bcdc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR2_ch07.pkl:   0%|          | 0/576 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR2_ch07_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR2_ch08.pkl 렌더링 시작 ---\n",
+      "Total frames: 576\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ea861890cf1c43d787c1d567d3041127",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR2_ch08.pkl:   0%|          | 0/576 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR2_ch08_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR2_ch09.pkl 렌더링 시작 ---\n",
+      "Total frames: 576\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "74d735d007a842c69f1997a070559f19",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR2_ch09.pkl:   0%|          | 0/576 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR2_ch09_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR2_ch10.pkl 렌더링 시작 ---\n",
+      "Total frames: 576\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7941e209f2bc40c282d132c0a75229d7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR2_ch10.pkl:   0%|          | 0/576 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR2_ch10_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR3_ch01.pkl 렌더링 시작 ---\n",
+      "Total frames: 524\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f81af0a3f70f4c01bceb9113f86bc622",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR3_ch01.pkl:   0%|          | 0/524 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR3_ch01_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR3_ch02.pkl 렌더링 시작 ---\n",
+      "Total frames: 524\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "540906423067487690b94c6c9ade6b1b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR3_ch02.pkl:   0%|          | 0/524 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR3_ch02_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR3_ch03.pkl 렌더링 시작 ---\n",
+      "Total frames: 524\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "970d50515b674f339b4c6df561d749a5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR3_ch03.pkl:   0%|          | 0/524 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR3_ch03_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR3_ch04.pkl 렌더링 시작 ---\n",
+      "Total frames: 524\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "49ff1f24bf704782b7f44ce6297c8ac9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR3_ch04.pkl:   0%|          | 0/524 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR3_ch04_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR3_ch05.pkl 렌더링 시작 ---\n",
+      "Total frames: 524\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c063d2457fa54545a0452c5b7d847fac",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR3_ch05.pkl:   0%|          | 0/524 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR3_ch05_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR3_ch06.pkl 렌더링 시작 ---\n",
+      "Total frames: 524\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6a55171a7eca4ef4886d227fbb1c6000",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR3_ch06.pkl:   0%|          | 0/524 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR3_ch06_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR3_ch07.pkl 렌더링 시작 ---\n",
+      "Total frames: 524\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8ad786bbb9c44687bfb77683cc2ae815",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR3_ch07.pkl:   0%|          | 0/524 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR3_ch07_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR3_ch08.pkl 렌더링 시작 ---\n",
+      "Total frames: 524\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e093e5ae04f140609b6bbae6b6f8b691",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR3_ch08.pkl:   0%|          | 0/524 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR3_ch08_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR3_ch09.pkl 렌더링 시작 ---\n",
+      "Total frames: 524\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a74469cb303a4aafbeafa565ab053034",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR3_ch09.pkl:   0%|          | 0/524 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR3_ch09_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d04_mBR3_ch10.pkl 렌더링 시작 ---\n",
+      "Total frames: 524\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f53f197f1523497d8129191c3f11763e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d04_mBR3_ch10.pkl:   0%|          | 0/524 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d04_mBR3_ch10_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR0_ch01.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "afff02f9a98d4550b82f0cdcd82e58ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR0_ch01.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR0_ch01_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR0_ch02.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4cac0adba6744a1b860467b27f82c0fb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR0_ch02.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR0_ch02_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR0_ch03.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cf106f7ca302489e939b674a8795dd7f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR0_ch03.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR0_ch03_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR0_ch04.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1ddbfc3eb6004008a35cf598504632e4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR0_ch04.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR0_ch04_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR0_ch05.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f598961afe0b42deb663f810810bf672",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR0_ch05.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR0_ch05_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR0_ch06.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "79404532633842999b51fef668d8ce6e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR0_ch06.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR0_ch06_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR0_ch07.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8e79177a7721478a9d809f0701a2693f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR0_ch07.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR0_ch07_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR0_ch08.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bda25c15a32741559d2f382f26e2ffa2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR0_ch08.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR0_ch08_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR0_ch09.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "821eb3169f054c47806a87cee5cb0e50",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR0_ch09.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR0_ch09_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR0_ch10.pkl 렌더링 시작 ---\n",
+      "Total frames: 720\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "965f4c49ed1149b193e6bae807e3d68a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR0_ch10.pkl:   0%|          | 0/720 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR0_ch10_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR1_ch01.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a8125ab8703641e09c7abac1b87baf90",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR1_ch01.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR1_ch01_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR1_ch02.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "26b2bc589dc94ad385d79d740bc37f28",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR1_ch02.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR1_ch02_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR1_ch03.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "979f09f9ced548f081ddab7c6fc390ac",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR1_ch03.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR1_ch03_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR1_ch04.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "14b28fac725f487e9af5d67b4aeb3268",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR1_ch04.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR1_ch04_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR1_ch05.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "df38d179fb4f4eeb909a774bad04f606",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR1_ch05.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR1_ch05_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR1_ch06.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a27777530c0f4d08893073e85df71b90",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR1_ch06.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR1_ch06_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR1_ch07.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d5088e60017240f09f8b5643c316f9aa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR1_ch07.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR1_ch07_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR1_ch08.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e0e25774ee6e490eb45e5404ff33f5e1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR1_ch08.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR1_ch08_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR1_ch09.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fa712d30ca3b46a5b82fe975269bf418",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR1_ch09.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR1_ch09_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR1_ch10.pkl 렌더링 시작 ---\n",
+      "Total frames: 640\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e50da663888a40df940b3493c1b33c3d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR1_ch10.pkl:   0%|          | 0/640 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 완료: C:\\Users\\SongYoengEun\\Desktop\\cap\\dance_video\\gBR_sBM_cAll_d05_mBR1_ch10_body.mp4\n",
+      "\n",
+      "--- gBR_sBM_cAll_d05_mBR4_ch01.pkl 렌더링 시작 ---\n",
+      "Total frames: 480\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cc11b30711e8413e876fa5b89a8eb5bb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Rendering gBR_sBM_cAll_d05_mBR4_ch01.pkl:   0%|          | 0/480 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# MOTION_DIR 내의 모든 .pkl 파일 목록 가져오기\n",
+    "pkl_files = [f for f in os.listdir(MOTION_DIR) if f.endswith('.pkl')]\n",
+    "print(f\"총 {len(pkl_files)}개의 .pkl 파일을 찾았습니다.\")\n",
+    "\n",
+    "# 각 .pkl 파일에 대해 렌더링 함수 호출\n",
+    "for pkl_file in pkl_files:\n",
+    "    try:\n",
+    "        print(f\"\\n--- {pkl_file} 렌더링 시작 ---\")\n",
+    "        render_smpl_video_mesh(pkl_file)\n",
+    "    except Exception as e:\n",
+    "        print(f\" 오류 발생 ({pkl_file}): {e}\")\n",
+    "        continue\n",
+    "\n",
+    "print(\"\\n✓ 모든 파일 처리 완료!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ba99778-a26e-4ec1-b0a6-430694b8133f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (SMPL Env 3.9)",
+   "language": "python",
+   "name": "smpl_env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.23"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# ⭐ 설명

> 추가하려는 기능에 대해 간결하게 설명해주세요

- **프로젝트 결과물의 시각적 완성도 및 직관성 향상**을 위해 기존 2D 스켈레톤 출력 방식을 SMPL(Skinned Multi-Person Linear Model) 기반의 3D 인체 메쉬 렌더링으로 대체합니다.
- 단순한 뼈대 정보 대신, 실제 사람과 유사한 3D 바디 모델(인간 형태)을 영상으로 출력하여 결과 해석을 용이하게 합니다.

## ⭐ 작업 상세 내용

- [x] **필수 라이브러리 설치:** `smplx`, `trimesh`, `pyrender` 등 3D 모델 및 렌더링에 필요한 라이브러리 환경을 구축했습니다.
- [x] **모션 데이터 로드 및 전처리:** AIST++ 등 외부 `.pkl` 파일에서 SMPL 파라미터(포즈, 변환)를 성공적으로 로드했습니다.
- [x] **3D 좌표 정규화:** 영상 내에서 인물이 좌우/상하로 벗어나지 않도록, 프레임별 인체 중심(Center)을 계산하여 **X/Y축 고정 로직**을 구현했습니다.
- [x] **Pyrender를 이용한 3D 메쉬 렌더링:** SMPL 정점(Vertices) 데이터를 사용하여 Pyrender로 3D 메쉬를 렌더링하고, 이를 OpenCV를 통해 `.mp4` 파일로 저장하는 파이프라인을 완성했습니다.
- [x] **배치 처리 기능 구현:** `motions` 디렉터리 내의 모든 `.pkl` 파일을 일괄적으로 메쉬 비디오로 변환하는 코드를 추가했습니다.

## 📖 참고할 만한 자료

- **SMPL 모델 공식 웹사이트:**
  - [https://smpl.is.tue.mpg.de/](https://smpl.is.tue.mpg.de/) (SMPL 모델 정보 및 다운로드)
- **Pyrender 문서:**
  - [https://pyrender.readthedocs.io/en/latest/](https://pyrender.readthedocs.io/en/latest/) (3D 렌더링 라이브러리)
- **Trimesh 문서:**
  - [https://trimesh.org/](https://trimesh.org/) (3D 메쉬 데이터 처리 라이브러리)

Closes #41 