### PR TITLE
refactor: SMPL 렌더링 영상으로 경로 변경

### DIFF
--- a/HEJZ_back/src/main/java/com/HEJZ/HEJZ_back/domain/dance/service/S3DanceVideoService.java
+++ b/HEJZ_back/src/main/java/com/HEJZ/HEJZ_back/domain/dance/service/S3DanceVideoService.java
@@ -27,7 +27,7 @@ public class S3DanceVideoService {
 
     public String getPresignedUrl(String motionId) {
         try {
-            String key = "videos/videos/" + motionId + ".mp4";
+            String key = "final_videos/" + motionId + "_body.mp4";
 
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                     .bucket(bucketName)


### PR DESCRIPTION
* videos/videos/{motionId}.mp4 → final_videos/{motionId}_body.mp4
* 기존 스켈레톤 영상 유지, SMPL 영상 별도 경로 사용